### PR TITLE
resolve clickable warnings on build

### DIFF
--- a/clickable.json
+++ b/clickable.json
@@ -1,5 +1,5 @@
 {
-  "template": "qmake",
+  "builder": "qmake",
   "kill": "ISODrive",
   "default": "clean build click-build",
   "make_jobs": 4

--- a/ubuntutouch/manifest.json.in
+++ b/ubuntutouch/manifest.json.in
@@ -4,7 +4,7 @@
     "version": "0.6.6",
     "description": "Boot GNU/Linux distributions from off your Ubuntu Touch device",
     "architecture": "@CLICK_ARCH@",
-    "framework": "ubuntu-sdk-16.04",
+    "framework": "ubuntu-sdk-16.04.5",
     "maintainer": "Alfred Neumayer <dev.beidl@gmail.com>",
     "hooks": {
         "isodrive": {


### PR DESCRIPTION
The project configs generate some deprecation and framework warnings on clickable. This PR  resolves these.