### PR TITLE
Search for iso files recursively in Downloads directory

### DIFF
--- a/src/filemanager.cpp
+++ b/src/filemanager.cpp
@@ -14,21 +14,17 @@ FileManager::FileManager(QObject *parent) : QObject(parent)
 void FileManager::refresh()
 {
     QVariantList foundFiles;
-    QDirIterator iterator(QStandardPaths::writableLocation(QStandardPaths::DownloadLocation));
+    QDirIterator iterator(QStandardPaths::writableLocation(QStandardPaths::DownloadLocation), 
+        QStringList() << "*.iso", QDir::Files, QDirIterator::Subdirectories);
 
     while (iterator.hasNext()) {
-        const QString filePath = iterator.next();
-        const QFileInfo fileInfo(filePath);
-        const QString loweredFileName = filePath.toLower();
+        iterator.next();
 
-        if (!loweredFileName.endsWith(".iso"))
-            continue;
-
-        qDebug() << filePath << "matches";
+        qDebug() << iterator.filePath() << "matches";
         QVariantMap foundFileInfo;
 
-        foundFileInfo.insert("name", fileInfo.fileName());
-        foundFileInfo.insert("path", fileInfo.absoluteFilePath());
+        foundFileInfo.insert("name", iterator.fileName());
+        foundFileInfo.insert("path", iterator.filePath());
 
         qDebug() << foundFileInfo;
         foundFiles.push_back(foundFileInfo);


### PR DESCRIPTION
There are two issues opened requesting to make the directory ISO's are searched in configurable. While this can be a pain to implement, I did find I would have liked to be able  to put all my ISO's together in a subdirectory under Downloads. In this way I can clean the files in the Downloads directory and leave the subdirectory untouched. 

I also changed the search mechanism to make use of the native QtDirIterator filtering mechanism. 