### PR TITLE
Add .img support and scan Documents paths

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -206,8 +206,8 @@ ApplicationWindow {
         horizontalAlignment: Qt.AlignHCenter
         verticalAlignment: Qt.AlignVCenter
         wrapMode: Label.WrapAtWordBoundaryOrAnywhere
-        text: qsTr("No .iso files found in the 'Downloads' folder. " +
-                   "Download a hybrid ISO file to continue.")
+        text: qsTr("No .iso or .img files found in Downloads or Documents/iso. " +
+                   "Add a bootable image to continue.")
         visible: isoList.count < 1
         font.pixelSize: units.gu(3)
     }

--- a/src/filemanager.cpp
+++ b/src/filemanager.cpp
@@ -2,9 +2,12 @@
 
 #include <QFile>
 #include <QFileInfo>
+#include <QDir>
 #include <QDirIterator>
 #include <QRegularExpression>
 #include <QRegularExpressionMatch>
+#include <QStandardPaths>
+#include <QStringList>
 #include <unistd.h>
 
 FileManager::FileManager(QObject *parent) : QObject(parent)
@@ -14,20 +17,34 @@ FileManager::FileManager(QObject *parent) : QObject(parent)
 void FileManager::refresh()
 {
     QVariantList foundFiles;
-    QDirIterator iterator(QStandardPaths::writableLocation(QStandardPaths::DownloadLocation), 
-        QStringList() << "*.iso", QDir::Files, QDirIterator::Subdirectories);
+    const QString downloadsPath = QStandardPaths::writableLocation(QStandardPaths::DownloadLocation);
+    const QString documentsPath = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+    const QStringList searchPaths = QStringList()
+        << downloadsPath
+        << QDir(documentsPath).filePath("iso")
+        << QDir(documentsPath).filePath("flashdrive");
+    const QStringList nameFilters = QStringList() << "*.iso" << "*.img";
 
-    while (iterator.hasNext()) {
-        iterator.next();
+    for (const QString &path : searchPaths) {
+        QDir dir(path);
+        if (!dir.exists()) {
+            continue;
+        }
 
-        qDebug() << iterator.filePath() << "matches";
-        QVariantMap foundFileInfo;
+        QDirIterator iterator(dir.absolutePath(), nameFilters, QDir::Files, QDirIterator::Subdirectories);
 
-        foundFileInfo.insert("name", iterator.fileName());
-        foundFileInfo.insert("path", iterator.filePath());
+        while (iterator.hasNext()) {
+            iterator.next();
 
-        qDebug() << foundFileInfo;
-        foundFiles.push_back(foundFileInfo);
+            qDebug() << iterator.filePath() << "matches";
+            QVariantMap foundFileInfo;
+
+            foundFileInfo.insert("name", iterator.fileName());
+            foundFileInfo.insert("path", iterator.filePath());
+
+            qDebug() << foundFileInfo;
+            foundFiles.push_back(foundFileInfo);
+        }
     }
 
     this->m_foundFiles = foundFiles;


### PR DESCRIPTION
## Summary
- scan Downloads, Documents/iso, and Documents/flashdrive for images
- include .img alongside .iso
- update empty-state text to reflect new search locations

## Testing
- Not run locally (Ubuntu Touch environment not available)

## Issue
- https://github.com/fredldotme/ISODriveUT/issues/12