### PR TITLE
feat: support Documents iso/flashdrive paths and .img files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,17 @@
 ISODrive for Ubuntu Touch
 ========
 
-Use your Ubuntu Touch device to boot Linux distributions/ISO files on your PC
+Use your Ubuntu Touch device to boot Linux distributions/ISO files on your PC.
+
+## Supported image locations
+
+ISODrive scans the following directories for boot images:
+
+- `~/Downloads`
+- `~/Documents/iso`
+- `~/Documents/flashdrive`
+
+Supported image types:
+
+- `.iso`
+- `.img`

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -206,8 +206,8 @@ ApplicationWindow {
         horizontalAlignment: Qt.AlignHCenter
         verticalAlignment: Qt.AlignVCenter
         wrapMode: Label.WrapAtWordBoundaryOrAnywhere
-        text: qsTr("No .iso files found in the 'Downloads' folder. " +
-                   "Download a hybrid ISO file to continue.")
+        text: qsTr("No .iso or .img files found in Downloads, Documents/iso, or Documents/flashdrive. " +
+                   "Add a boot image to continue.")
         visible: isoList.count < 1
         font.pixelSize: units.gu(3)
     }

--- a/src/filemanager.cpp
+++ b/src/filemanager.cpp
@@ -3,8 +3,7 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QDirIterator>
-#include <QRegularExpression>
-#include <QRegularExpressionMatch>
+#include <QSet>
 #include <unistd.h>
 
 FileManager::FileManager(QObject *parent) : QObject(parent)
@@ -14,20 +13,38 @@ FileManager::FileManager(QObject *parent) : QObject(parent)
 void FileManager::refresh()
 {
     QVariantList foundFiles;
-    QDirIterator iterator(QStandardPaths::writableLocation(QStandardPaths::DownloadLocation), 
-        QStringList() << "*.iso", QDir::Files, QDirIterator::Subdirectories);
+    QSet<QString> seenPaths;
 
-    while (iterator.hasNext()) {
-        iterator.next();
+    const QStringList roots = searchRoots();
+    for (const QString& root : roots) {
+        const QDir rootDir(root);
+        if (!rootDir.exists()) {
+            qDebug() << "Skipping missing directory:" << root;
+            continue;
+        }
 
-        qDebug() << iterator.filePath() << "matches";
-        QVariantMap foundFileInfo;
+        QDirIterator iterator(root,
+                              QDir::Files,
+                              QDirIterator::Subdirectories);
 
-        foundFileInfo.insert("name", iterator.fileName());
-        foundFileInfo.insert("path", iterator.filePath());
+        while (iterator.hasNext()) {
+            iterator.next();
+            if (!isBootImageFile(iterator.fileName())) {
+                continue;
+            }
 
-        qDebug() << foundFileInfo;
-        foundFiles.push_back(foundFileInfo);
+            const QString absolutePath = iterator.filePath();
+            if (seenPaths.contains(absolutePath)) {
+                continue;
+            }
+            seenPaths.insert(absolutePath);
+
+            qDebug() << absolutePath << "matches";
+            QVariantMap foundFileInfo;
+            foundFileInfo.insert("name", iterator.fileName());
+            foundFileInfo.insert("path", absolutePath);
+            foundFiles.push_back(foundFileInfo);
+        }
     }
 
     this->m_foundFiles = foundFiles;
@@ -45,4 +62,26 @@ bool FileManager::removeFile(const QString &filePath)
     const bool ret = QFile::remove(absolutePath);
     sync();
     return ret;
+}
+
+QStringList FileManager::searchRoots() const
+{
+    const QString downloadsPath = QStandardPaths::writableLocation(QStandardPaths::DownloadLocation);
+    const QString documentsPath = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+
+    QStringList roots;
+    roots << downloadsPath;
+
+    if (!documentsPath.isEmpty()) {
+        roots << QDir(documentsPath).filePath("iso");
+        roots << QDir(documentsPath).filePath("flashdrive");
+    }
+
+    return roots;
+}
+
+bool FileManager::isBootImageFile(const QString &fileName)
+{
+    const QString lowerName = fileName.toLower();
+    return lowerName.endsWith(".iso") || lowerName.endsWith(".img");
 }

--- a/src/filemanager.h
+++ b/src/filemanager.h
@@ -21,6 +21,9 @@ private:
     QVariantList foundFiles();
     QVariantList m_foundFiles;
 
+    QStringList searchRoots() const;
+    static bool isBootImageFile(const QString& fileName);
+
 signals:
     void foundFilesChanged();
 


### PR DESCRIPTION
## Summary
- add support for both `.iso` and `.img` boot images
- scan additional folders requested in the bounty issue:
  - `~/Documents/iso`
  - `~/Documents/flashdrive`
- keep `~/Downloads` scanning as-is
- update empty-state UI text and README to reflect new behavior

## Why
Issue #12 asks for:
1) custom path support under Documents (`/documents/iso` and `/documents/flashdrive`)
2) `.img` file support in addition to `.iso`

This PR implements both directly in `FileManager::refresh()`.

## Validation
- manual code-path verification in `FileManager`:
  - scans Downloads + Documents subfolders
  - filters to `.iso`/`.img` (case-insensitive)
  - de-duplicates discovered paths
- tooling note: `qmake` is not available in this CI shell (`qmake: command not found`), so a full Qt build could not be executed here.

Fixes #12
