### PR TITLE
feat: USB mass storage status indicator and proper ConfigFS gadget control

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -24,7 +24,14 @@ ApplicationWindow {
         visible: !(dialogIsOpen || settingsDialogOpen)
         title: qsTr("ISODrive")
 
-        subtitle: qsTr("Active: %1").arg(activeIso)
+        subtitle: {
+            if (isoManager.usbActive && hasLoadedIso)
+                return qsTr("USB: Mass Storage | Active: %1").arg(activeIso)
+            else if (isoManager.usbActive)
+                return qsTr("USB: Mass Storage Active")
+            else
+                return qsTr("Active: %1").arg(activeIso)
+        }
 
         trailingActionBar.actions: [
             Action {

--- a/src/configfsisomanager.cpp
+++ b/src/configfsisomanager.cpp
@@ -145,7 +145,37 @@ bool ConfigFSIsoManager::isEnabledISO(const QString absolutePath)
 
 void ConfigFSIsoManager::resetISO()
 {
-    enableISO("");
+    const QString gadgetRoot = getGadgetRoot();
+    const QString functionRoot = gadgetRoot + QStringLiteral("/functions");
+    const QString massStorageRoot = functionRoot + QStringLiteral("/mass_storage.0");
+    const QString lunRoot = massStorageRoot + QStringLiteral("/lun.0");
+    const QString lunFile = lunRoot + QStringLiteral("/file");
+
+    resetUDC();
+
+    // Clear the LUN file to release the ISO
+    this->m_commandRunner->writeFile(lunFile, QByteArrayLiteral(""));
+    this->m_commandRunner->writeFile(massStorageRoot + QStringLiteral("/stall"), QByteArrayLiteral("0"));
+
+    emit selectedISOChanged();
+}
+
+bool ConfigFSIsoManager::isUsbActive()
+{
+    const QString gadgetRoot = getGadgetRoot();
+    const QString udcFile = gadgetRoot + QStringLiteral("/UDC");
+    const QByteArray udcContent = this->m_commandRunner->readFile(udcFile);
+    return !QString::fromUtf8(udcContent).trimmed().isEmpty();
+}
+
+void ConfigFSIsoManager::setUsbActive(bool active)
+{
+    if (active) {
+        setUDC();
+    } else {
+        resetUDC();
+    }
+    emit usbActiveChanged();
 }
 
 QString ConfigFSIsoManager::getSelectedISOPath()

--- a/src/configfsisomanager.h
+++ b/src/configfsisomanager.h
@@ -11,6 +11,7 @@ class ConfigFSIsoManager : public GenericIsoManager
     Q_OBJECT
     Q_PROPERTY(QString userPassword READ userPassword WRITE setUserPassword NOTIFY userPasswordChanged)
     Q_PROPERTY(QString selectedISO READ getSelectedISO NOTIFY selectedISOChanged)
+    Q_PROPERTY(bool usbActive READ isUsbActive NOTIFY usbActiveChanged)
 
 public:
     explicit ConfigFSIsoManager(QObject *parent = nullptr);
@@ -19,6 +20,8 @@ public:
     Q_INVOKABLE bool isEnabledISO(QString fileName) Q_DECL_OVERRIDE;
     Q_INVOKABLE void resetISO() Q_DECL_OVERRIDE;
     Q_INVOKABLE bool validatePassword();
+    Q_INVOKABLE bool isUsbActive();
+    Q_INVOKABLE void setUsbActive(bool active);
 
 private:
     QString userPassword();
@@ -38,6 +41,7 @@ signals:
     void selectedISOChanged();
     void selectionFailed();
     void userPasswordChanged();
+    void usbActiveChanged();
 
 };
 

--- a/src/utisomanager.cpp
+++ b/src/utisomanager.cpp
@@ -116,3 +116,15 @@ QString UtIsoManager::getSelectedISO()
     fileName = fileName.replace("\n", "");
     return fileName.trimmed();
 }
+
+bool UtIsoManager::isUsbActive()
+{
+    return enabled();
+}
+
+void UtIsoManager::setUsbActive(bool active)
+{
+    setEnabled(active);
+    emit usbActiveChanged();
+}
+

--- a/src/utisomanager.h
+++ b/src/utisomanager.h
@@ -11,6 +11,7 @@ class UtIsoManager : public GenericIsoManager
     Q_OBJECT
     Q_PROPERTY(QString userPassword READ userPassword WRITE setUserPassword NOTIFY userPasswordChanged)
     Q_PROPERTY(QString selectedISO READ getSelectedISO NOTIFY selectedISOChanged)
+    Q_PROPERTY(bool usbActive READ isUsbActive NOTIFY usbActiveChanged)
 
 public:
     explicit UtIsoManager(QObject *parent = nullptr);
@@ -19,6 +20,8 @@ public:
     Q_INVOKABLE bool isEnabledISO(QString fileName) Q_DECL_OVERRIDE;
     Q_INVOKABLE void resetISO() Q_DECL_OVERRIDE;
     Q_INVOKABLE bool validatePassword();
+    Q_INVOKABLE bool isUsbActive();
+    Q_INVOKABLE void setUsbActive(bool active);
 
 private:
     QString userPassword();
@@ -37,6 +40,7 @@ signals:
     void selectedISOChanged();
     void selectionFailed();
     void userPasswordChanged();
+    void usbActiveChanged();
 
 };
 


### PR DESCRIPTION
## Summary

Implements USB mass storage mode visibility and proper gadget control for ISODrive, addressing the bounty issue #12.

## Changes

### ConfigFSIsoManager Improvements
- **isUsbActive()**: New method that reads the UDC (USB Device Controller) file to determine if the USB gadget is currently active/connected
- **setUsbActive(bool)**: New method allowing explicit enable/disable of the USB gadget via UDC
- **Fixed resetISO()**: Properly resets the USB gadget:
  - Resets UDC before clearing LUN (required sequence)
  - Clears the LUN file to release the ISO
  - Resets stall to 0
  - Emits selectedISOChanged signal for UI update

### UtIsoManager Improvements
- Added isUsbActive() and setUsbActive() methods as convenience wrappers around existing enabled()/setEnabled()

### QML UI Update
- Header subtitle now dynamically shows USB mass storage status:
  - "USB: Mass Storage | Active: <filename>" when USB active with ISO loaded
  - "USB: Mass Storage Active" when USB active but no ISO
  - "Active: <filename>" when ISO loaded but USB not yet active

## Testing

The implementation follows the existing code patterns and uses the same sysfs/configfs interfaces already used by the app. The USB status is read from the actual gadget UDC state.

## Bounty

Bounty: $50 USD
Issue: https://github.com/fredldotme/ISODriveUT/issues/12
Payment: eB51DWp1uECrLZRLsE2cnyZUzfRWvzUzaJzkatTpQV9 (BTC)

---
Closes #12