### PR TITLE
Support .img files and Documents scan paths

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -206,8 +206,8 @@ ApplicationWindow {
         horizontalAlignment: Qt.AlignHCenter
         verticalAlignment: Qt.AlignVCenter
         wrapMode: Label.WrapAtWordBoundaryOrAnywhere
-        text: qsTr("No .iso files found in the 'Downloads' folder. " +
-                   "Download a hybrid ISO file to continue.")
+        text: qsTr("No .iso or .img files found in Downloads or Documents/iso " +
+                   "or Documents/flashdrive. Add a hybrid image to continue.")
         visible: isoList.count < 1
         font.pixelSize: units.gu(3)
     }

--- a/src/filemanager.cpp
+++ b/src/filemanager.cpp
@@ -3,6 +3,7 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QDirIterator>
+#include <QStandardPaths>
 #include <QRegularExpression>
 #include <QRegularExpressionMatch>
 #include <unistd.h>
@@ -14,20 +15,29 @@ FileManager::FileManager(QObject *parent) : QObject(parent)
 void FileManager::refresh()
 {
     QVariantList foundFiles;
-    QDirIterator iterator(QStandardPaths::writableLocation(QStandardPaths::DownloadLocation), 
-        QStringList() << "*.iso", QDir::Files, QDirIterator::Subdirectories);
+    const QStringList scanRoots = {
+        QStandardPaths::writableLocation(QStandardPaths::DownloadLocation),
+        QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation) + QStringLiteral("/iso"),
+        QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation) + QStringLiteral("/flashdrive")
+    };
+    const QStringList filters = { QStringLiteral("*.iso"), QStringLiteral("*.img") };
 
-    while (iterator.hasNext()) {
-        iterator.next();
+    for (const QString &root : scanRoots) {
+        if (root.isEmpty())
+            continue;
+        QDirIterator iterator(root, filters, QDir::Files, QDirIterator::Subdirectories);
+        while (iterator.hasNext()) {
+            iterator.next();
 
-        qDebug() << iterator.filePath() << "matches";
-        QVariantMap foundFileInfo;
+            qDebug() << iterator.filePath() << "matches";
+            QVariantMap foundFileInfo;
 
-        foundFileInfo.insert("name", iterator.fileName());
-        foundFileInfo.insert("path", iterator.filePath());
+            foundFileInfo.insert("name", iterator.fileName());
+            foundFileInfo.insert("path", iterator.filePath());
 
-        qDebug() << foundFileInfo;
-        foundFiles.push_back(foundFileInfo);
+            qDebug() << foundFileInfo;
+            foundFiles.push_back(foundFileInfo);
+        }
     }
 
     this->m_foundFiles = foundFiles;


### PR DESCRIPTION
Fixes #12.

- Scan Downloads + Documents/iso + Documents/flashdrive
- Support .img alongside .iso
- Update empty-state copy