### PR TITLE
Add Documents scans and .img boot image support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@ ISODrive for Ubuntu Touch
 ========
 
 Use your Ubuntu Touch device to boot Linux distributions/ISO files on your PC
+
+Scans Downloads, Documents/iso, Documents/flashdrive; accepts `.iso` + `.img`.

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -206,8 +206,8 @@ ApplicationWindow {
         horizontalAlignment: Qt.AlignHCenter
         verticalAlignment: Qt.AlignVCenter
         wrapMode: Label.WrapAtWordBoundaryOrAnywhere
-        text: qsTr("No .iso files found in the 'Downloads' folder. " +
-                   "Download a hybrid ISO file to continue.")
+        text: qsTr("No .iso or .img files found in Downloads, Documents/iso, " +
+                   "or Documents/flashdrive. Download or copy a boot image to continue.")
         visible: isoList.count < 1
         font.pixelSize: units.gu(3)
     }

--- a/src/filemanager.cpp
+++ b/src/filemanager.cpp
@@ -5,6 +5,7 @@
 #include <QDirIterator>
 #include <QRegularExpression>
 #include <QRegularExpressionMatch>
+#include <QSet>
 #include <unistd.h>
 
 FileManager::FileManager(QObject *parent) : QObject(parent)
@@ -14,20 +15,35 @@ FileManager::FileManager(QObject *parent) : QObject(parent)
 void FileManager::refresh()
 {
     QVariantList foundFiles;
-    QDirIterator iterator(QStandardPaths::writableLocation(QStandardPaths::DownloadLocation), 
-        QStringList() << "*.iso", QDir::Files, QDirIterator::Subdirectories);
+    const QStringList roots = {
+        QStandardPaths::writableLocation(QStandardPaths::DownloadLocation),
+        QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation) + QStringLiteral("/iso"),
+        QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation) + QStringLiteral("/flashdrive")
+    };
 
-    while (iterator.hasNext()) {
-        iterator.next();
+    QSet<QString> seen;
+    for (const QString &root : roots) {
+        if (root.isEmpty() || !QDir(root).exists())
+            continue;
 
-        qDebug() << iterator.filePath() << "matches";
-        QVariantMap foundFileInfo;
+        QDirIterator iterator(root, QDir::Files, QDirIterator::Subdirectories);
+        while (iterator.hasNext()) {
+            iterator.next();
 
-        foundFileInfo.insert("name", iterator.fileName());
-        foundFileInfo.insert("path", iterator.filePath());
+            const QFileInfo info(iterator.filePath());
+            const QString suffix = info.suffix().toLower();
+            if (suffix != QStringLiteral("iso") && suffix != QStringLiteral("img"))
+                continue;
+            if (seen.contains(info.canonicalFilePath()))
+                continue;
+            seen.insert(info.canonicalFilePath());
 
-        qDebug() << foundFileInfo;
-        foundFiles.push_back(foundFileInfo);
+            qDebug() << iterator.filePath() << "matches";
+            QVariantMap foundFileInfo;
+            foundFileInfo.insert("name", iterator.fileName());
+            foundFileInfo.insert("path", iterator.filePath());
+            foundFiles.push_back(foundFileInfo);
+        }
     }
 
     this->m_foundFiles = foundFiles;

--- a/ubuntutouch/isodrive.apparmor
+++ b/ubuntutouch/isodrive.apparmor
@@ -4,6 +4,12 @@
     "read_path": [
         "@{HOME}/Downloads",
         "@{HOME}/Downloads/*",
+        "@{HOME}/Documents",
+        "@{HOME}/Documents/*",
+        "@{HOME}/Documents/iso",
+        "@{HOME}/Documents/iso/*",
+        "@{HOME}/Documents/flashdrive",
+        "@{HOME}/Documents/flashdrive/*",
         "/sys/devices/virtual/android_usb/android0/enable",
         "/sys/devices/virtual/android_usb/android0/f_mass_storage/lun/file"
     ],


### PR DESCRIPTION
Fixes #12.

- scan Downloads, Documents/iso, Documents/flashdrive
- accept .iso + .img
- expand AppArmor allowlist
- update empty-state copy