### PR TITLE
feat: support Documents image paths and writable .img images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 ISODrive for Ubuntu Touch
 ========
 
-Use your Ubuntu Touch device to boot Linux distributions/ISO files on your PC
+Use your Ubuntu Touch device to boot Linux distributions/ISO and IMG files on your PC

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -206,8 +206,8 @@ ApplicationWindow {
         horizontalAlignment: Qt.AlignHCenter
         verticalAlignment: Qt.AlignVCenter
         wrapMode: Label.WrapAtWordBoundaryOrAnywhere
-        text: qsTr("No .iso files found in the 'Downloads' folder. " +
-                   "Download a hybrid ISO file to continue.")
+        text: qsTr("No .iso or .img files found. Check 'Downloads', " +
+                   "'Documents/iso', and 'Documents/flashdrive' for a boot image.")
         visible: isoList.count < 1
         font.pixelSize: units.gu(3)
     }

--- a/src/configfsisomanager.cpp
+++ b/src/configfsisomanager.cpp
@@ -6,6 +6,7 @@
 #include <QDirIterator>
 #include <QDBusReply>
 #include <QFileInfo>
+#include <QString>
 
 ConfigFSIsoManager::ConfigFSIsoManager(QObject *parent) :
     GenericIsoManager(parent),
@@ -97,6 +98,7 @@ void ConfigFSIsoManager::enableISO(const QString& fileName, const bool enableSha
     const QString lunRo = lunRoot + QStringLiteral("/ro");
 
     const QByteArray selectedIso = fileName.toUtf8();
+    const bool isDiskImage = fileName.endsWith(QStringLiteral(".img"), Qt::CaseInsensitive);
 
     resetUDC();
 
@@ -111,7 +113,7 @@ void ConfigFSIsoManager::enableISO(const QString& fileName, const bool enableSha
 
     this->m_commandRunner->writeFile(lunFile, selectedIso);
     this->m_commandRunner->writeFile(lunCdRom, "0");
-    this->m_commandRunner->writeFile(lunRo, "1");
+    this->m_commandRunner->writeFile(lunRo, isDiskImage ? "0" : "1");
 
     setUDC();
 

--- a/src/filemanager.cpp
+++ b/src/filemanager.cpp
@@ -7,6 +7,23 @@
 #include <QRegularExpressionMatch>
 #include <unistd.h>
 
+namespace {
+QStringList imageSearchRoots()
+{
+    QStringList roots;
+    roots << QStandardPaths::writableLocation(QStandardPaths::DownloadLocation);
+
+    const QString documentsRoot =
+        QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+    if (!documentsRoot.isEmpty()) {
+        roots << documentsRoot + QStringLiteral("/iso");
+        roots << documentsRoot + QStringLiteral("/flashdrive");
+    }
+
+    return roots;
+}
+}
+
 FileManager::FileManager(QObject *parent) : QObject(parent)
 {
 }
@@ -14,20 +31,27 @@ FileManager::FileManager(QObject *parent) : QObject(parent)
 void FileManager::refresh()
 {
     QVariantList foundFiles;
-    QDirIterator iterator(QStandardPaths::writableLocation(QStandardPaths::DownloadLocation), 
-        QStringList() << "*.iso", QDir::Files, QDirIterator::Subdirectories);
+    const QStringList nameFilters = QStringList() << "*.iso" << "*.img";
 
-    while (iterator.hasNext()) {
-        iterator.next();
+    for (const QString &root : imageSearchRoots()) {
+        if (!QDir(root).exists())
+            continue;
 
-        qDebug() << iterator.filePath() << "matches";
-        QVariantMap foundFileInfo;
+        QDirIterator iterator(root, nameFilters, QDir::Files,
+                              QDirIterator::Subdirectories);
 
-        foundFileInfo.insert("name", iterator.fileName());
-        foundFileInfo.insert("path", iterator.filePath());
+        while (iterator.hasNext()) {
+            iterator.next();
 
-        qDebug() << foundFileInfo;
-        foundFiles.push_back(foundFileInfo);
+            qDebug() << iterator.filePath() << "matches";
+            QVariantMap foundFileInfo;
+
+            foundFileInfo.insert("name", iterator.fileName());
+            foundFileInfo.insert("path", iterator.filePath());
+
+            qDebug() << foundFileInfo;
+            foundFiles.push_back(foundFileInfo);
+        }
     }
 
     this->m_foundFiles = foundFiles;


### PR DESCRIPTION
Fixes #12

- scan `~/Downloads`, `~/Documents/iso`, and `~/Documents/flashdrive`
- include both `.iso` and `.img` boot images
- keep `.img` writable in configfs so it behaves like a flash drive
- update empty-state text + README

Validation: qmake unavailable in this shell (`qmake: command not found`), so no full Qt build here.